### PR TITLE
commit-pushスキルを日本語化し、コミットメッセージガイドラインを追加

### DIFF
--- a/.github/skills/commit-push/SKILL.md
+++ b/.github/skills/commit-push/SKILL.md
@@ -2,26 +2,45 @@
 name: commit-push
 description: git commitとgit pushを実行するスキル
 license: Apache-2.0
-compatibility: Requires git to be installed and configured on the system.
+compatibility: gitがシステムにインストールされ、設定されている必要があります。
 metadata:
   author: org
   version: "1.0"
   tags: [git, version control, commit, push]
-  description: This skill automates the process of committing changes to a git repository and pushing them to a remote server. It is designed to streamline the workflow for developers by providing a simple interface for managing git commits and pushes.
+  description: このスキルは、gitリポジトリへの変更をコミットし、リモートサーバーにプッシュするプロセスを自動化します。シンプルなインターフェースでgitのコミットとプッシュを管理し、開発者のワークフローを効率化することを目的としています。
   usage: |
-    1. Ensure you have git installed and configured on your system.
-    2. Use the skill to stage changes, create a commit message, and push to the remote repository.
-    3. The skill will guide you through the process, allowing you to review changes before committing and pushing.
+    1. gitがシステムにインストールされ、設定されていることを確認してください。
+    2. このスキルを使用して変更をステージし、コミットメッセージを作成し、リモートリポジトリにプッシュします。
+    3. スキルがプロセスをガイドし、コミットとプッシュの前に変更内容を確認できます。
+    4. **コミットメッセージには必ずタイトルと実施内容の要約を含めてください**:
+       - 1行目: 簡潔なタイトル（50文字以内推奨）
+       - 2行目: 空行
+       - 3行目以降: 変更内容の詳細説明（何を、なぜ変更したか）
   examples: |
-    - Example 1: Committing and pushing changes to the main branch.
-      1. Stage changes: `git add .`
-      2. Create commit message: "Add new feature X"
-      3. Push to remote: `git push origin main`
-    - Example 2: Committing and pushing changes to a feature branch.
-      1. Stage changes: `git add .`
-      2. Create commit message: "Fix bug Y"
-      3. Push to remote: `git push origin feature-branch`
+    - 例1: mainブランチへの変更をコミット・プッシュ
+      1. 変更をステージ: `git add .`
+      2. コミットメッセージを作成:
+         ```
+         新機能Xを追加
+
+         - ユーザー認証機能を実装
+         - ログイン画面のUI改善
+         - セッション管理ロジックを追加
+         ```
+      3. リモートにプッシュ: `git push origin main`
+    - 例2: フィーチャーブランチへの変更をコミット・プッシュ
+      1. 変更をステージ: `git add .`
+      2. コミットメッセージを作成:
+         ```
+         バグYを修正
+
+         - NullPointerExceptionの原因を特定し修正
+         - エラーハンドリングを強化
+         - 該当箇所のユニットテストを追加
+         ```
+      3. リモートにプッシュ: `git push origin feature-branch`
   references: |
-    - [Git Documentation](https://git-scm.com/doc)
-    - [GitHub Guides](https://guides.github.com/introduction/git-handbook/) 
+    - [Git ドキュメント](https://git-scm.com/doc)
+    - [GitHub ガイド](https://guides.github.com/introduction/git-handbook/)
+    - [コミットメッセージの書き方](https://www.conventionalcommits.org/ja/)
 ---


### PR DESCRIPTION
- 全ての説明文を日本語に翻訳
- コミットメッセージの形式ガイドライン追加（タイトル+要約）
- 具体的な例を複数追加（複数行コミットメッセージ）
- Conventional Commitsへの参考リンクを追加